### PR TITLE
enforce flush:true when save and updating the user info

### DIFF
--- a/grails-app/services/org/transmart/plugin/auth0/Auth0Service.groovy
+++ b/grails-app/services/org/transmart/plugin/auth0/Auth0Service.groovy
@@ -317,7 +317,7 @@ class Auth0Service implements InitializingBean {
 			description.picture = credentials.picture ?: ''
 
 			user.description = (description as JSON).toString()
-			user.save()
+			user.save(flush:true)
 			if (user.hasErrors()) {
 				logger.error 'Error updating user{}: {}', credentials.username, utilService.errorStrings(user)
 			}


### PR DESCRIPTION
We need this, otherwise it doesn't save description on user create and update. It didn't work in docker and locally